### PR TITLE
fix file remote path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ lerna-debug.log*
 *.csv
 *.cursor
 *.clock
+*.spkg
 
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json

--- a/README.md
+++ b/README.md
@@ -42,10 +42,15 @@ SUBSTREAMS_API_KEY=<your-api-key>
 MANIFEST=https://github.com/streamingfast/substreams-eth-block-meta/releases/download/v0.5.1/substreams-eth-block-meta-v0.5.1.spkg
 MODULE_NAME=graph_out
 SUBSTREAMS_ENDPOINT=eth.substreams.pinax.network:443
+SCHEMA=schema.example.sql
 ```
-**CLI**
+**CLI** with `.env` file
 ```bash
-$ substreams-sink-csv --schema schema.sql
+$ substreams-sink-csv
+```
+**CLI** with `params`
+```bash
+$ substreams-sink-csv --schema schema.example.sql -e eth.substreams.pinax.network:443 --module-name graph_out --manifest https://github.com/streamingfast/substreams-eth-block-meta/releases/download/v0.5.1/substreams-eth-block-meta-v0.5.1.spkg --substreams-api-key <your-api-key>
 ```
 
 ### Substreams Support

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "substreams-sink-csv",
-    "version": "0.2.2",
+    "version": "0.2.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "substreams-sink-csv",
-            "version": "0.2.2",
+            "version": "0.2.3",
             "dependencies": {
                 "@substreams/sink-entity-changes": "^0.3.9",
                 "log-update": "latest",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.2.3",
+    "version": "0.2.4",
     "name": "substreams-sink-csv",
     "description": "Substreams Sink CSV",
     "type": "module",
@@ -26,7 +26,7 @@
         }
     },
     "scripts": {
-        "start": "tsc && node ./dist/bin/cli.js --help",
+        "start": "tsc && node ./dist/bin/cli.js",
         "pretest": "tsc --noEmit",
         "test": "bun test",
         "prepublishOnly": "tsc"

--- a/src/getModuleHash.ts
+++ b/src/getModuleHash.ts
@@ -2,6 +2,10 @@ import { readPackage } from "@substreams/manifest";
 import { CSVRunOptions } from "../bin/cli.js";
 import { createModuleHashHex } from "@substreams/core";
 
+export function isRemotePath(path: string): boolean {
+  return path.startsWith("http://") || path.startsWith("https://");
+}
+
 export async function getModuleHash(options: CSVRunOptions) {
     // Read Substream
     const substreamPackage = await readPackage(options.manifest);


### PR DESCRIPTION
- fix issue with reading local spkg file

Following `.env` should work:

```.env
// local file
MANIFEST=./src/substreams-eth-block-meta-v0.5.1.spkg
MANIFEST=substreams-eth-block-meta-v0.5.1.spkg
MANIFEST=/usr/local/share/substreams-eth-block-meta-v0.5.1.spkg

// remote URL
MANIFEST=https://github.com/streamingfast/substreams-eth-block-meta/releases/download/v0.5.1/substreams-eth-block-meta-v0.5.1.spkg
```