### PR TITLE
add blocks per second to logging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,16 @@
 {
     "name": "substreams-sink-csv",
-    "version": "0.2.3",
+    "version": "0.2.7",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "substreams-sink-csv",
-            "version": "0.2.3",
+            "version": "0.2.7",
             "dependencies": {
                 "@substreams/sink-entity-changes": "^0.3.9",
                 "log-update": "latest",
-                "substreams-sink": "^0.15.1"
+                "substreams-sink": "^0.15.2"
             },
             "bin": {
                 "substreams-sink-csv": "dist/bin/cli.js"
@@ -565,9 +565,9 @@
             }
         },
         "node_modules/substreams-sink": {
-            "version": "0.15.1",
-            "resolved": "https://registry.npmjs.org/substreams-sink/-/substreams-sink-0.15.1.tgz",
-            "integrity": "sha512-oKm4Aln3AoYienp2lAtVW4gl2FEH33FK0riCh1aaOyGJq8N+JwM2yFf38qVI+/mnX53tEXgi+ema/NfeF0zY0A==",
+            "version": "0.15.2",
+            "resolved": "https://registry.npmjs.org/substreams-sink/-/substreams-sink-0.15.2.tgz",
+            "integrity": "sha512-nbvdn1a4pcOlf2NIkzTcZS2aa5Cv0pBWJ17jxvBoSRyHDCw/tTFivsJAwsrdNGgs7srQLhGVtn1nwmxezsR+UA==",
             "dependencies": {
                 "@substreams/core": "^0.15.1",
                 "@substreams/manifest": "^0.14.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "dependencies": {
         "@substreams/sink-entity-changes": "^0.3.9",
         "log-update": "latest",
-        "substreams-sink": "^0.15.1"
+        "substreams-sink": "^0.15.2"
     },
     "devDependencies": {
         "@types/bun": "latest",


### PR DESCRIPTION
```json
{
  "last_block_num": 30404,
  "last_timestamp": "2015-08-04T03:19:42.000Z",
  "blocks": 11154,
  "rows": 22310,
  "blocksPerSecond": 301,
  "totalBytesRead": 285284924,
  "totalBytesWritten": 0,
  "runningJobs": 0
}
```