### PR TITLE
improve writeRow logic

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,4 @@ MANIFEST=https://github.com/streamingfast/substreams-eth-block-meta/releases/dow
 MODULE_NAME=graph_out
 SUBSTREAMS_ENDPOINT=eth.substreams.pinax.network:443
 SCHEMA=schema.example.sql
+DELIMITER=","

--- a/bin/cli.mts
+++ b/bin/cli.mts
@@ -8,6 +8,7 @@ import { version } from "../version.js";
 export interface CSVRunOptions extends commander.RunOptions {
   schema: string;
   filename?: string;
+  delimiter: string;
 }
 
 const name = "substreams-sink-csv";
@@ -18,7 +19,8 @@ const pkg = {name, version, description};
 const program = commander.program(pkg);
 const command = commander.addRunOptions(program, {metrics: false, http: false});
 command.addOption(new Option("--filename <string>", "CSV filename (default: '<endpoint>-<module_hash>-<module_name>.csv')").env("FILENAME"));
-command.addOption(new Option("--schema <string>", "SQL Table Schema for CSV").default("schema.sql").env("SCHEMA"));
+command.addOption(new Option("--schema <string>", "SQL table schema for CSV").default("schema.sql").env("SCHEMA"));
+command.addOption(new Option("--delimiter <string>", "CSV delimiter").default(",").env("DELIMITER"));
 command.action(action);
 
 program.parse();

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "substreams-sink": "^0.16.0"
             },
             "bin": {
-                "substreams-sink-csv": "dist/bin/cli.js"
+                "substreams-sink-csv": "dist/bin/cli.mjs"
             },
             "devDependencies": {
                 "@types/bun": "latest",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "version": "0.2.9",
+    "version": "0.2.10",
     "name": "substreams-sink-csv",
     "description": "Substreams Sink CSV",
     "type": "module",

--- a/src/applyReservedFields.ts
+++ b/src/applyReservedFields.ts
@@ -1,0 +1,29 @@
+import { Clock } from "@substreams/core/proto"
+import { EntityChange } from "@substreams/sink-entity-changes/zod";
+import { parseClock, parseTimestamp } from "./parseClock.js";
+import { Timestamp } from "@bufbuild/protobuf";
+
+export function applyReservedFields( values: Record<string, unknown>, entityChange: EntityChange, cursor: string, clock: Clock ) {
+    const { block_number, block_id, timestamp, seconds, milliseconds, nanos } = parseClock(clock);
+
+    // **Reserved field names** to be used to expand the schema
+    if ( !values["id"] ) values["id"] = entityChange.id;
+    if ( !values["operation"] ) values["operation"] = entityChange.operation;
+    if ( !values["cursor"] ) values["cursor"] = cursor;
+    if ( !values["block"] ) values["block"] = block_number;
+    if ( !values["block_num"] ) values["block_num"] = block_number;
+    if ( !values["block_number"] ) values["block_number"] = block_number;
+    if ( !values["block_id"] ) values["block_id"] = block_id;
+    if ( !values["seconds"] ) values["seconds"] = seconds;
+    if ( !values["milliseconds"] ) values["milliseconds"] = milliseconds;
+    if ( !values["millis"] ) values["millis"] = milliseconds;
+    if ( !values["nanos"] ) values["nanos"] = nanos;
+    if ( !values["nanoseconds"] ) values["nanoseconds"] = nanos;
+    if ( !values["timestamp"] ) values["timestamp"] = timestamp;
+
+    // exception parsing timestamp
+    if ( values["timestamp"] ) values["timestamp"] = parseTimestamp(Timestamp.fromDate(new Date(values["timestamp"] as string)));
+    else values["timestamp"] = timestamp;
+
+    return values;
+}

--- a/src/parseClock.spec.ts
+++ b/src/parseClock.spec.ts
@@ -1,0 +1,8 @@
+import { expect, test } from "bun:test";
+import { parseTimestamp } from "./parseClock.js";
+import { Timestamp } from "@bufbuild/protobuf";
+
+test("parseTimestamp", () => {
+    // expect(parseTimestamp(timestamp)).toBe("2015-07-30T15:26:57.000Z");
+    expect(parseTimestamp(Timestamp.fromDate(new Date(1438270017000)))).toBe("2015-07-30 15:26:57");
+})

--- a/src/parseClock.ts
+++ b/src/parseClock.ts
@@ -1,11 +1,22 @@
 import { Clock } from "@substreams/core/proto";
+import { Timestamp } from "@bufbuild/protobuf";
 
 export function parseClock(clock: Clock) {
-    if ( !clock.timestamp ) throw new Error("Clock has no timestamp");
-    return {
-      block_num: Number(clock.number),
-      block_id: clock.id,
-      seconds: Number(clock.timestamp?.seconds),
-      timestamp: clock.timestamp?.toDate().toISOString(),
-    }
+  if ( !clock.timestamp ) throw new Error("Clock has no timestamp");
+  const seconds = Number(clock.timestamp?.seconds);
+  const nanos = Number(clock.timestamp?.nanos);
+  const milliseconds = seconds * 1000 + nanos / 1000000;
+
+  return {
+    block_number: Number(clock.number),
+    block_id: clock.id,
+    seconds,
+    milliseconds,
+    nanos,
+    timestamp: parseTimestamp(clock.timestamp)
   }
+}
+
+export function parseTimestamp(timestamp: Timestamp) {
+  return timestamp.toDate().toISOString().replace("T", " ").split(".")[0]
+}

--- a/src/writeRow.spec.ts
+++ b/src/writeRow.spec.ts
@@ -1,0 +1,14 @@
+import { expect, test } from "bun:test";
+import { formatValue } from "./writeRow.js";
+
+test("formatValue", () => {
+    const options = {delimiter: ","};
+    // expect(formatValue("a", options)).toBe("a");
+    expect(formatValue("'a'", options)).toBe("'a'");
+    expect(formatValue("foo bar", options)).toBe("foo bar");
+    expect(formatValue("foo \" bar", options)).toBe("foo \"\" bar");
+    expect(formatValue(undefined, options)).toBe("");
+    expect(formatValue(null, options)).toBe("");
+    expect(formatValue("a,b", options)).toBe("\"a,b\"");
+    expect(formatValue("a,\"b", options)).toBe("\"a,\"\"b\"");
+})

--- a/src/writeRow.ts
+++ b/src/writeRow.ts
@@ -1,0 +1,20 @@
+import fs from "fs";
+
+interface WriteRowOptions {
+    delimiter: string;
+}
+
+export function writeRow(writer: fs.WriteStream, columns: any[], options: WriteRowOptions): void {
+    columns = columns.map(value => formatValue(value, options));
+    writer.write(columns.join(options.delimiter) + '\n');
+}
+
+export function formatValue(value: string|undefined|null, options: WriteRowOptions): string {
+    if (value === undefined || value === null) return "";
+
+    if (typeof value == "string") {
+        value = value.replace(/"/g, "\"\"")
+        if ( value.includes(options.delimiter) ) value = `"${value}"`; // escape commas
+    }
+    return value;
+}

--- a/version.ts
+++ b/version.ts
@@ -1,1 +1,1 @@
-export const version = "0.2.9";
+export const version = "0.2.10";


### PR DESCRIPTION
- improve `writeRow` logic
  - `formatValue` based on CSV rules
- add Clickhouse CSV handling to docs
- support `DELIMITER` `--delimiter` flag (default ",")
- add additional reserved key values:
  - block_number
  - block
  - nanos
  - nanoseconds
  - milliseconds
  - millis
- formatted `timestamp` to `2016-06-15 23:00:00` (supported by Clickhouse)
- add `applyReservedFields` method
- if `timestamp` exists, apply `parseTimestamp` logic

fixes https://github.com/pinax-network/substreams-sink-csv/issues/19